### PR TITLE
conflict

### DIFF
--- a/test/data/test_data.py
+++ b/test/data/test_data.py
@@ -49,15 +49,15 @@ def test_data():
     assert clone.x.tolist() == data.x.tolist()
     assert clone.edge_index.tolist() == data.edge_index.tolist()
 
-    # test to_heterogenous
-    hetero_data = data.to_heterogeneous()
-    assert torch.allclose(data.x, hetero_data['0'].x)
-    assert torch.allclose(data.edge_index,
-                          hetero_data['0', '0'].edge_index)
+    # Test `data.to_heterogenous()`:
+    out = data.to_heterogeneous()
+    assert torch.allclose(data.x, out['0'].x)
+    assert torch.allclose(data.edge_index, out['0', '0'].edge_index)
+
     data.edge_type = torch.tensor([0, 0, 1, 0])
-    hetero_data = data.to_heterogeneous()
-    assert torch.allclose(data.x, hetero_data['0'].x)
-    assert [3, 1] == [i.edge_index.size(1) for i in hetero_data.edge_stores]
+    out = data.to_heterogeneous()
+    assert torch.allclose(data.x, out['0'].x)
+    assert [store.num_edges for store in out.edge_stores] == [3, 1]
     data.edge_type = None
 
     data['x'] = x + 1

--- a/test/nn/conv/test_hetero_conv.py
+++ b/test/nn/conv/test_hetero_conv.py
@@ -2,7 +2,8 @@ import pytest
 
 import torch
 from torch_geometric.data import HeteroData
-from torch_geometric.nn import GCNConv, SAGEConv, GATConv, HeteroConv
+from torch_geometric.nn import HeteroConv, Linear
+from torch_geometric.nn import MessagePassing, GCNConv, SAGEConv, GATConv
 
 
 def get_edge_index(num_src_nodes, num_dst_nodes, num_edges):
@@ -41,3 +42,32 @@ def test_hetero_conv(aggr):
     else:
         assert out['paper'].size() == (50, 2, 64)
         assert out['author'].size() == (30, 1, 64)
+
+
+class CustomConv(MessagePassing):
+    def __init__(self, out_channels):
+        super().__init__(aggr='add')
+        self.lin = Linear(-1, out_channels)
+
+    def forward(self, x, edge_index, pos):
+        return self.propagate(edge_index, x=x, pos=pos)
+
+    def message(self, x_j, pos_i, pos_j):
+        return self.lin(torch.cat([x_j, pos_i - pos_j], dim=-1))
+
+
+def test_hetero_conv_with_custom_conv():
+    data = HeteroData()
+    data['paper'].x = torch.randn(50, 32)
+    data['paper'].pos = torch.randn(50, 3)
+    data['author'].x = torch.randn(30, 64)
+    data['author'].pos = torch.randn(30, 3)
+    data['paper', 'paper'].edge_index = get_edge_index(50, 50, 200)
+    data['paper', 'author'].edge_index = get_edge_index(50, 30, 100)
+    data['author', 'paper'].edge_index = get_edge_index(30, 50, 100)
+
+    conv = HeteroConv({key: CustomConv(64) for key in data.edge_types})
+    out = conv(data.x_dict, data.edge_index_dict, data.pos_dict)
+    assert len(out) == 2
+    assert out['paper'].size() == (50, 64)
+    assert out['author'].size() == (30, 64)

--- a/torch_geometric/data/data.py
+++ b/torch_geometric/data/data.py
@@ -516,15 +516,16 @@ class Data(BaseData):
                 edge_type_names.append((node_type_names[src_types[0]], str(i),
                                         node_type_names[dst_types[0]]))
 
-        # iterate over node types to get node slices
-        # and index_map, which contains the index of each node
-        # in the heterogenous graph.
-        node_ids, index_map = {}, torch.zeros_like(node_type)
+        # We iterate over node types to find the local node indices belonging
+        # to each node type. Furthermore, we create a global `index_map` vector
+        # that maps global node indices to local ones in the final
+        # heterogeneous graph:
+        node_ids, index_map = {}, torch.empty_like(node_type)
         for i, key in enumerate(node_type_names):
             node_ids[i] = (node_type == i).nonzero(as_tuple=False).view(-1)
             index_map[node_ids[i]] = torch.arange(len(node_ids[i]))
 
-        # iterate over edge types to get edge slices
+        # We iterate over edge types to find the local edge indices:
         edge_ids = {}
         for i, key in enumerate(edge_type_names):
             edge_ids[i] = (edge_type == i).nonzero(as_tuple=False).view(-1)
@@ -539,7 +540,7 @@ class Data(BaseData):
                     data[key][attr] = value[node_ids[i]]
 
             if len(data[key]) == 0:
-                data[key].num_nodes = len(node_ids[i])
+                data[key].num_nodes = node_ids[i].size(0)
 
         for i, key in enumerate(edge_type_names):
             src, _, dst = key

--- a/torch_geometric/transforms/face_to_edge.py
+++ b/torch_geometric/transforms/face_to_edge.py
@@ -16,7 +16,7 @@ class FaceToEdge(BaseTransform):
         self.remove_faces = remove_faces
 
     def __call__(self, data):
-        if data.face is not None:
+        if hasattr(data, 'face'):
             face = data.face
             edge_index = torch.cat([face[:2], face[1:], face[::2]], dim=1)
             edge_index = to_undirected(edge_index, num_nodes=data.num_nodes)


### PR DESCRIPTION
As discussed in this issue [#3061](https://github.com/pyg-team/pytorch_geometric/issues/3061#issue-985437172) This PR implements the pathlib.Path keeping in mind the changes to pathlib library in python 3.8. The changes should support python 3.6 and python 3.9 for both torch 1.8.* and 1.9.*. The test and benchmark modules still use os.path which can be changed if required.  

